### PR TITLE
fix: Include memtable data in fullScan() and rangeQuery() — freshly inserted rows now visible to SELECT

### DIFF
--- a/StorageEngine/SQLLayer/query_executor.cpp
+++ b/StorageEngine/SQLLayer/query_executor.cpp
@@ -442,10 +442,16 @@ namespace sql
                 "DELETE only supports WHERE <pk> = <value>");
 
         std::string key = SchemaRegistry::encodeKey(tableName, *pkVal);
+
+        // Check if the row exists before deleting
+        auto existing = engine_.get(key);
+        if (!existing.has_value())
+            return ResultSet::affected(0, "Row not found");
+
         bool ok = engine_.del(key);
 
         return ok ? ResultSet::affected(1)
-                  : ResultSet::affected(0, "Row not found");
+                  : ResultSet::error("Storage engine delete failed");
     }
 
     // ================================================================
@@ -574,7 +580,15 @@ namespace sql
         case hsql::kExprLiteralInt:
             return std::to_string(expr->ival);
         case hsql::kExprLiteralFloat:
-            return std::to_string(expr->fval);
+        {
+            std::string s = std::to_string(expr->fval);
+            // Strip trailing zeros: "300.000000" -> "300"
+            if (s.find('.') != std::string::npos) {
+                s.erase(s.find_last_not_of('0') + 1, std::string::npos);
+                if (s.back() == '.') s.pop_back();
+            }
+            return s;
+        }
         case hsql::kExprLiteralString:
             return expr->name ? std::string(expr->name) : "";
         case hsql::kExprLiteralNull:

--- a/StorageEngine/SQLLayer/tests/Unit_Test2.cpp
+++ b/StorageEngine/SQLLayer/tests/Unit_Test2.cpp
@@ -466,7 +466,7 @@ void testSelectWhere()
     // Numeric less than
     auto r3 = ctx.run("SELECT * FROM orders WHERE amount < 100");
     assertOk(r3, "WHERE amount < 100");
-    assertRowCount(r3, 1, "1 order with amount < 100");
+    assertRowCount(r3, 2, "2 orders with amount < 100");
 
     // Greater than or equal
     auto r4 = ctx.run("SELECT * FROM orders WHERE amount >= 250");

--- a/StorageEngine/includes/storage_engine.hpp
+++ b/StorageEngine/includes/storage_engine.hpp
@@ -254,12 +254,11 @@ public:
 
     rangeQueryCount_++;
 
-    // Plan the query
-    auto request = query::QueryRequest::rangeScan(startKey, endKey);
-    auto plan = queryRouter_->planQuery(request);
+    // Get memtable results first (freshly inserted, not yet flushed)
+    auto memResults = memtableManager_->rangeQuery(startKey, endKey);
 
-    // Execute using range query executor
-    return rangeQueryExecutor_->executeSSTableRange(startKey, endKey);
+    // Merge memtable + SSTable results
+    return rangeQueryExecutor_->executeWithMemtable(startKey, endKey, memResults);
   }
 
   // Execute range query with memtable results
@@ -275,7 +274,15 @@ public:
   // Full table scan
   std::vector<std::pair<std::string, std::string>> fullScan() {
     rangeQueryCount_++;
-    return rangeQueryExecutor_->fullScan();
+
+    std::string minKey = "";
+    std::string maxKey(256, '\xff');
+
+    // Get memtable results (freshly inserted, not yet flushed)
+    auto memResults = memtableManager_->rangeQuery(minKey, maxKey);
+
+    // Merge memtable + SSTable results
+    return rangeQueryExecutor_->executeWithMemtable(minKey, maxKey, memResults);
   }
 
   // ==================== Aggregations (OLAP) ====================


### PR DESCRIPTION
## Problem

When a user inserts data and immediately queries it, the data is not returned:

```sql
samanvay> INSERT INTO test VALUES(1);
Query OK, 1 row(s) affected (3 ms)

samanvay> SELECT * FROM test;
+----+
| id |
+----+
+----+
0 row(s) in set
```

### Root Cause

`INSERT` writes data to the **memtable** (in-memory skip list). The data only reaches **SSTables** (on disk) after a flush — which happens when the memtable reaches 64 MB.

However, `fullScan()` and `rangeQuery()` in `StorageEngine` were **only reading SSTables**, completely skipping the memtable. This meant any data not yet flushed to disk was invisible to `SELECT *` and `SELECT ... WHERE <non-pk>` queries.

Notably, **point lookups** (`SELECT ... WHERE pk = X`) worked correctly because `get()` already checked the memtable first:

```cpp
// get() — correct ✅
auto memResult = memtableManager_->search(key);
if (memResult.has_value()) return memResult;
return searchInSSTables(key);

// fullScan() — broken ❌
return rangeQueryExecutor_->fullScan(); // SSTables only!
```

## Solution

### Approach chosen: Fix at the Storage Engine facade level

Wire `memtableManager_->rangeQuery()` into both `fullScan()` and `rangeQuery()`, and use the existing `RangeQueryExecutor::executeWithMemtable()` to merge memtable + SSTable results.

### Alternatives considered

| # | Approach | Verdict |
|---|----------|---------|
| 1 | **Fix at Storage Engine level** (chosen) | Minimal change (~4 lines per method), uses existing merge logic, right abstraction layer |
| 2 | Fix at SQL Query Executor level | Duplicates merge logic, SQL layer shouldn't know about memtable internals, violates facade pattern |
| 3 | Force flush before every SELECT | Correct results but **terrible performance** — every read triggers a disk write |
| 4 | Give RangeQueryExecutor a memtable pointer | Adds unnecessary coupling between components; harder to test independently |
| 5 | Make memtable a virtual Level-0 SSTable | Architecturally elegant but massive refactor for a simple bug |

**Why option 1?** It's the right abstraction layer (storage engine facade), matches how `get()` already works, uses code that was already written (`executeWithMemtable()`), and requires the fewest changes.

### Performance impact

Negligible. The memtable scan is an in-memory skip list traversal (microseconds) vs SSTable disk I/O (milliseconds). The merge map insertion adds O(n) operations where n is the memtable size. This is consistent with how production LSM-tree databases (RocksDB, LevelDB) work — memtable is always the first layer checked.

## Changes

### 1. `StorageEngine::fullScan()` — [StorageEngine/includes/storage_engine.hpp](StorageEngine/includes/storage_engine.hpp)

**Before:** Called `rangeQueryExecutor_->fullScan()` which only scanned SSTables.

**After:** Queries memtable via `memtableManager_->rangeQuery(minKey, maxKey)`, then passes results to `rangeQueryExecutor_->executeWithMemtable()` which merges memtable + SSTable data with proper deduplication (memtable entries win conflicts via `UINT64_MAX` sequence number).

### 2. `StorageEngine::rangeQuery()` — [StorageEngine/includes/storage_engine.hpp](StorageEngine/includes/storage_engine.hpp)

**Before:** Called `rangeQueryExecutor_->executeSSTableRange()` (SSTables only). Also computed a query plan via the router that was never used (dead code).

**After:** Same fix as `fullScan()` — queries memtable first, merges with SSTable results via `executeWithMemtable()`. Removed the unused `request`/`plan` variables.

### 3. `QueryExecutor::executeDelete()` — [StorageEngine/SQLLayer/query_executor.cpp](StorageEngine/SQLLayer/query_executor.cpp)

**Before:** `engine_.del(key)` always returned `true` (tombstone written successfully), so `DELETE ... WHERE pk = 999` reported "1 row affected" even for non-existent rows.

**After:** Calls `engine_.get(key)` first to verify the row exists. Returns `rowsAffected = 0` if not found.

### 4. `QueryExecutor::exprToString()` — [StorageEngine/SQLLayer/query_executor.cpp](StorageEngine/SQLLayer/query_executor.cpp)

**Before:** `std::to_string(300.0)` produced `"300.000000"`.

**After:** Strips trailing zeros from DOUBLE literals (`"300.000000"` → `"300"`, `"75.500000"` → `"75.5"`).

### 5. Test fix — [StorageEngine/SQLLayer/tests/Unit_Test2.cpp](StorageEngine/SQLLayer/tests/Unit_Test2.cpp)

Fixed incorrect test expectation: `WHERE amount < 100` matches **2** rows (99.99 and 75.50), not 1.

## Test Results

**Before:** 134 passed, 13 failed
**After:** 147 passed, 0 failed

## Checklist

- [x] All 147 unit tests pass
- [x] No new warnings introduced
- [x] Changes are backward compatible
- [x] No public API changes
- [x] Existing `get()`, `put()`, `del()` behavior unchanged